### PR TITLE
Update gradle to 7.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.util.DistributionLocator
+import org.gradle.util.GradleVersion
+
+wrapper {
+    distributionType = 'ALL'
+    doLast {
+        final DistributionLocator locator = new DistributionLocator()
+        final GradleVersion version = GradleVersion.version(wrapper.gradleVersion)
+        final URI distributionUri = locator.getDistributionFor(version, wrapper.distributionType.name().toLowerCase(Locale.ENGLISH))
+        final URI sha256Uri = new URI(distributionUri.toString() + ".sha256")
+        final String sha256Sum = new String(sha256Uri.toURL().bytes)
+        wrapper.getPropertiesFile() << "distributionSha256Sum=${sha256Sum}\n"
+        println "Added checksum to wrapper properties"
+    }
+}
 
 allprojects {
     // https://docs.gradle.org/current/userguide/java_library_plugin.html
@@ -81,7 +96,7 @@ allprojects {
         integrationTest {
             java.srcDir file('src/integration-test/java')
             resources.srcDir file('src/integration-test/resources')
-            compileClasspath += sourceSets.main.output + configurations.testRuntime
+            compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
             runtimeClasspath += output + compileClasspath
         }
     }
@@ -95,7 +110,7 @@ allprojects {
 
     checkstyle {
         toolVersion "8.44"
-        configDir rootProject.file("checkstyle/")
+        configDirectory.set(rootProject.file("checkstyle/"))
     }
 
     test {
@@ -122,7 +137,7 @@ allprojects {
             exclude group: "org.apache.logging.log4j", module: "log4j-core"
         }
 
-        compile "org.slf4j:slf4j-api:$slf4jVersion"
+        implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
         testImplementation "org.mockito:mockito-core:3.5.7"
         testImplementation "org.mockito:mockito-junit-jupiter:3.5.7"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b13f5d97f08000996bf12d9dd70af3f2c6b694c2c663ab1b545e9695562ad1ee
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=c9490e938b221daf0094982288e4038deed954a3f12fb54cbf270ddf4e37d879

--- a/repository-azure/build.gradle
+++ b/repository-azure/build.gradle
@@ -20,7 +20,7 @@ ext {
 }
 
 dependencies {
-    compile project(':repository-commons')
+    implementation project(':repository-commons')
 
     implementation("com.azure:azure-core-http-okhttp:$azureStorageOkHttpVerison") {
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
@@ -50,8 +50,8 @@ dependencies {
         exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-xml"
     }
 
-    testCompile project(':repository-commons').sourceSets.test.output
-    testCompile project(':repository-commons').sourceSets.integrationTest.java
+    testImplementation project(':repository-commons').sourceSets.test.output
+    testImplementation project(':repository-commons').sourceSets.integrationTest.java
 
     integrationTestImplementation project(':repository-commons').sourceSets.integrationTest.output
 }

--- a/repository-commons/build.gradle
+++ b/repository-commons/build.gradle
@@ -23,5 +23,5 @@ dependencies {
     implementation "com.github.luben:zstd-jni:$zstdVersion"
     implementation "org.bouncycastle:bcprov-jdk15on:$bcVersion"
 
-    compile "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
 }

--- a/repository-gcs/build.gradle
+++ b/repository-gcs/build.gradle
@@ -19,14 +19,14 @@ ext {
 }
 
 dependencies {
-    compile project(':repository-commons')
+    implementation project(':repository-commons')
 
     implementation("com.google.cloud:google-cloud-storage:$gcsVerison") {
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
     }
 
-    testCompile project(':repository-commons').sourceSets.test.output
-    testCompile project(':repository-commons').sourceSets.integrationTest.java
+    testImplementation project(':repository-commons').sourceSets.test.output
+    testImplementation project(':repository-commons').sourceSets.integrationTest.java
 
     integrationTestImplementation "com.google.cloud:google-cloud-storage:$gcsVerison"
     integrationTestImplementation project(':repository-commons').sourceSets.integrationTest.output

--- a/repository-s3/build.gradle
+++ b/repository-s3/build.gradle
@@ -19,7 +19,7 @@ ext {
 }
 
 dependencies {
-    compile project(':repository-commons')
+    implementation project(':repository-commons')
 
     implementation ("com.amazonaws:aws-java-sdk-s3:$awsVerison") {
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
@@ -28,8 +28,8 @@ dependencies {
     }
 
 
-    testCompile project(':repository-commons').sourceSets.test.output
-    testCompile project(':repository-commons').sourceSets.integrationTest.java
+    testImplementation project(':repository-commons').sourceSets.test.output
+    testImplementation project(':repository-commons').sourceSets.integrationTest.java
 
     integrationTestImplementation "com.amazonaws:aws-java-sdk-s3:$awsVerison"
 


### PR DESCRIPTION
Besides normal upgrade part with changing of deprecations 
there is also wrapper which ensures that during next update of gradle it will keep `all` as distributedType and it will update checksum as well