### PR TITLE
Affix settings

### DIFF
--- a/repository-azure/src/main/java/io/aiven/elasticsearch/repositories/azure/AzureClientSettings.java
+++ b/repository-azure/src/main/java/io/aiven/elasticsearch/repositories/azure/AzureClientSettings.java
@@ -18,6 +18,9 @@ package io.aiven.elasticsearch.repositories.azure;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import org.opensearch.common.settings.SecureSetting;
 import org.opensearch.common.settings.SecureString;
@@ -28,46 +31,84 @@ import org.opensearch.common.unit.TimeValue;
 import io.aiven.elasticsearch.repositories.CommonSettings;
 
 import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.checkSettings;
+import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.getConfigValue;
 import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.readInputStream;
-import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.withPrefix;
 
 public class AzureClientSettings implements CommonSettings.ClientSettings {
+
+    static final String AZURE_PREFIX = AIVEN_PREFIX + "azure.";
 
     static final String AZURE_CONNECTION_STRING_TEMPLATE =
             "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s";
 
-    static final Setting<Integer> AZURE_HTTP_POOL_MIN_THREADS =
-            Setting.intSetting(withPrefix("azure.http.thread_pool.min"),
-                    Runtime.getRuntime().availableProcessors() * 2 - 1, 1, Setting.Property.NodeScope);
+    static final Setting.AffixSetting<Integer> AZURE_HTTP_POOL_MIN_THREADS =
+            Setting.affixKeySetting(
+                    AZURE_PREFIX,
+                    "http.thread_pool.min",
+                    key -> Setting.intSetting(key,
+                            Runtime.getRuntime().availableProcessors() * 2 - 1, 1,
+                            Setting.Property.NodeScope)
+            );
 
-    static final Setting<Integer> AZURE_HTTP_POOL_MAX_THREADS =
-            Setting.intSetting(withPrefix("azure.http.thread_pool.max"),
-                    Runtime.getRuntime().availableProcessors() * 2 - 1, 1, Setting.Property.NodeScope);
+    static final Setting.AffixSetting<Integer> AZURE_HTTP_POOL_MAX_THREADS =
+            Setting.affixKeySetting(
+                    AZURE_PREFIX,
+                    "http.thread_pool.max",
+                    key -> Setting.intSetting(key,
+                            Runtime.getRuntime().availableProcessors() * 2 - 1, 1,
+                            Setting.Property.NodeScope)
+            );
 
-    static final Setting<TimeValue> AZURE_HTTP_POOL_KEEP_ALIVE =
-            Setting.timeSetting(withPrefix("azure.http.thread_pool.keep_alive"), TimeValue.timeValueSeconds(30L),
-                    Setting.Property.NodeScope);
+    static final Setting.AffixSetting<TimeValue> AZURE_HTTP_POOL_KEEP_ALIVE =
+            Setting.affixKeySetting(
+                    AZURE_PREFIX,
+                    "http.thread_pool.keep_alive",
+                    key -> Setting.timeSetting(key, TimeValue.timeValueSeconds(30L), Setting.Property.NodeScope)
+            );
 
-    static final Setting<Integer> AZURE_HTTP_POOL_WORKING_QUEUE_SIZE =
-            Setting.intSetting(withPrefix("azure.http.thread_pool.working_queue_size"), 1000, 10,
-                    Setting.Property.NodeScope);
+    static final Setting.AffixSetting<Integer> AZURE_HTTP_POOL_WORKING_QUEUE_SIZE =
+            Setting.affixKeySetting(
+                    AZURE_PREFIX,
+                    "http.thread_pool.working_queue_size",
+                    key -> Setting.intSetting(key, 1000, 10, Setting.Property.NodeScope)
+            );
 
 
-    public static final Setting<InputStream> PUBLIC_KEY_FILE =
-            SecureSetting.secureFile(withPrefix("azure.public_key_file"), null);
+    public static final Setting.AffixSetting<InputStream> PUBLIC_KEY_FILE =
+            Setting.affixKeySetting(
+                    AZURE_PREFIX,
+                    "public_key_file",
+                    key -> SecureSetting.secureFile(key, null)
+            );
 
-    public static final Setting<InputStream> PRIVATE_KEY_FILE =
-            SecureSetting.secureFile(withPrefix("azure.private_key_file"), null);
+    public static final Setting.AffixSetting<InputStream> PRIVATE_KEY_FILE =
+            Setting.affixKeySetting(
+                    AZURE_PREFIX,
+                    "private_key_file",
+                    key -> SecureSetting.secureFile(key, null)
+            );
 
-    public static final Setting<SecureString> AZURE_ACCOUNT =
-            SecureSetting.secureString(withPrefix("azure.client.account"), null);
+    public static final Setting.AffixSetting<SecureString> AZURE_ACCOUNT =
+            Setting.affixKeySetting(
+                    AZURE_PREFIX,
+                    "client.account",
+                    key -> SecureSetting.secureString(key, null)
+            );
 
-    public static final Setting<SecureString> AZURE_ACCOUNT_KEY =
-            SecureSetting.secureString(withPrefix("azure.client.account.key"), null);
+    public static final Setting.AffixSetting<SecureString> AZURE_ACCOUNT_KEY =
+            Setting.affixKeySetting(
+                    AZURE_PREFIX,
+                    "client.account.key",
+                    key -> SecureSetting.secureString(key, null)
+            );
 
     //default is 3 please take a look ExponentialBackoff azure class
-    public static final Setting<Integer> MAX_RETRIES =
-            Setting.intSetting(withPrefix("max_retries"), 3, Setting.Property.NodeScope);
+    public static final Setting.AffixSetting<Integer> MAX_RETRIES =
+            Setting.affixKeySetting(
+                    AZURE_PREFIX,
+                    "max_retries",
+                    key -> Setting.intSetting(key, 3, Setting.Property.NodeScope)
+            );
 
     private final byte[] publicKey;
 
@@ -119,22 +160,31 @@ public class AzureClientSettings implements CommonSettings.ClientSettings {
         return maxRetries;
     }
 
-    public static AzureClientSettings create(final Settings settings) throws IOException {
-        checkSettings(AZURE_ACCOUNT, settings);
-        checkSettings(AZURE_ACCOUNT_KEY, settings);
-        checkSettings(PUBLIC_KEY_FILE, settings);
-        checkSettings(PRIVATE_KEY_FILE, settings);
+    public static Map<String, AzureClientSettings> create(final Settings settings) throws IOException {
+        final Set<String> clientNames = settings.getGroups(AZURE_PREFIX).keySet();
+        final var clientSettings = new HashMap<String, AzureClientSettings>();
+        for (final var clientName : clientNames) {
+            clientSettings.put(clientName, createSettings(clientName, settings));
+        }
+        return Map.copyOf(clientSettings);
+    }
+
+    static AzureClientSettings createSettings(final String clientName, final Settings settings) throws IOException {
+        checkSettings(AZURE_ACCOUNT, clientName, settings);
+        checkSettings(AZURE_ACCOUNT_KEY, clientName, settings);
+        checkSettings(PUBLIC_KEY_FILE, clientName, settings);
+        checkSettings(PRIVATE_KEY_FILE, clientName, settings);
         return new AzureClientSettings(
-                readInputStream(PUBLIC_KEY_FILE, settings),
-                readInputStream(PRIVATE_KEY_FILE, settings),
-                AZURE_ACCOUNT.get(settings).toString(),
-                AZURE_ACCOUNT_KEY.get(settings).toString(),
-                MAX_RETRIES.get(settings),
+                readInputStream(getConfigValue(settings, clientName, PUBLIC_KEY_FILE)),
+                readInputStream(getConfigValue(settings, clientName, PRIVATE_KEY_FILE)),
+                getConfigValue(settings, clientName, AZURE_ACCOUNT).toString(),
+                getConfigValue(settings, clientName, AZURE_ACCOUNT_KEY).toString(),
+                getConfigValue(settings, clientName, MAX_RETRIES),
                 new HttpThreadPoolSettings(
-                        AZURE_HTTP_POOL_MIN_THREADS.get(settings),
-                        AZURE_HTTP_POOL_MAX_THREADS.get(settings),
-                        AZURE_HTTP_POOL_KEEP_ALIVE.get(settings).getMillis(),
-                        AZURE_HTTP_POOL_WORKING_QUEUE_SIZE.get(settings))
+                        getConfigValue(settings, clientName, AZURE_HTTP_POOL_MIN_THREADS),
+                        getConfigValue(settings, clientName, AZURE_HTTP_POOL_MAX_THREADS),
+                        getConfigValue(settings, clientName, AZURE_HTTP_POOL_KEEP_ALIVE).getMillis(),
+                        getConfigValue(settings, clientName, AZURE_HTTP_POOL_WORKING_QUEUE_SIZE))
         );
     }
 

--- a/repository-azure/src/main/java/io/aiven/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
+++ b/repository-azure/src/main/java/io/aiven/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
@@ -25,12 +25,14 @@ import io.aiven.elasticsearch.repositories.AbstractRepositoryPlugin;
 
 import com.azure.storage.blob.BlobServiceClient;
 
+import static io.aiven.elasticsearch.repositories.azure.AzureClientSettings.AZURE_PREFIX;
+
 public class AzureRepositoryPlugin extends AbstractRepositoryPlugin<BlobServiceClient, AzureClientSettings> {
 
     public static final String REPOSITORY_TYPE = "aiven-azure";
 
     public AzureRepositoryPlugin(final Settings settings) {
-        super(REPOSITORY_TYPE, settings, new AzureSettingsProvider());
+        super(REPOSITORY_TYPE, AZURE_PREFIX, settings, new AzureSettingsProvider());
     }
 
     @Override

--- a/repository-azure/src/main/java/io/aiven/elasticsearch/repositories/azure/AzureRepositoryStorageIOProvider.java
+++ b/repository-azure/src/main/java/io/aiven/elasticsearch/repositories/azure/AzureRepositoryStorageIOProvider.java
@@ -37,7 +37,6 @@ import io.aiven.elasticsearch.repositories.CommonSettings;
 import io.aiven.elasticsearch.repositories.Permissions;
 import io.aiven.elasticsearch.repositories.RepositoryStorageIOProvider;
 import io.aiven.elasticsearch.repositories.io.CryptoIOProvider;
-import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
@@ -50,9 +49,8 @@ public class AzureRepositoryStorageIOProvider
 
     static final Setting<String> CONTAINER_NAME = Setting.simpleString("container_name");
 
-    public AzureRepositoryStorageIOProvider(final AzureClientSettings clientSettings,
-                                            final EncryptionKeyProvider encryptionKeyProvider) {
-        super(new AzureClientProvider(), clientSettings, encryptionKeyProvider);
+    public AzureRepositoryStorageIOProvider(final Map<String, AzureClientSettings> clientSettings) {
+        super(new AzureClientProvider(), clientSettings);
     }
 
     @Override

--- a/repository-azure/src/main/java/io/aiven/elasticsearch/repositories/azure/AzureSettingsProvider.java
+++ b/repository-azure/src/main/java/io/aiven/elasticsearch/repositories/azure/AzureSettingsProvider.java
@@ -23,7 +23,6 @@ import org.opensearch.common.settings.Settings;
 import io.aiven.elasticsearch.repositories.Permissions;
 import io.aiven.elasticsearch.repositories.RepositorySettingsProvider;
 import io.aiven.elasticsearch.repositories.RepositoryStorageIOProvider;
-import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 
 import com.azure.storage.blob.BlobServiceClient;
 
@@ -34,10 +33,8 @@ public class AzureSettingsProvider extends RepositorySettingsProvider<BlobServic
             final Settings settings) throws IOException {
         return Permissions.doPrivileged(() -> {
             final var azureClientSettings = AzureClientSettings.create(settings);
-            final var encryptionKeyProvider =
-                    EncryptionKeyProvider.of(azureClientSettings.publicKey(), azureClientSettings.privateKey());
             return Permissions.doPrivileged(() ->
-                    new AzureRepositoryStorageIOProvider(azureClientSettings, encryptionKeyProvider));
+                    new AzureRepositoryStorageIOProvider(azureClientSettings));
         });
     }
 

--- a/repository-azure/src/test/java/io/aiven/elasticsearch/repositories/azure/AzureClientProviderTest.java
+++ b/repository-azure/src/test/java/io/aiven/elasticsearch/repositories/azure/AzureClientProviderTest.java
@@ -39,6 +39,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static io.aiven.elasticsearch.repositories.CommonSettings.RepositorySettings.MAX_RETRIES;
+import static io.aiven.elasticsearch.repositories.azure.AzureClientSettings.AZURE_ACCOUNT;
+import static io.aiven.elasticsearch.repositories.azure.AzureClientSettings.AZURE_ACCOUNT_KEY;
+import static io.aiven.elasticsearch.repositories.azure.AzureClientSettings.PRIVATE_KEY_FILE;
+import static io.aiven.elasticsearch.repositories.azure.AzureClientSettings.PUBLIC_KEY_FILE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -109,8 +113,9 @@ class AzureClientProviderTest extends RsaKeyAwareTest {
                         .put("some_settings_2", 210)
                         .build();
 
+        final var azureClientSettings = AzureClientSettings.create(settings);
         final var client = azureClientProvider
-                .buildClientIfNeeded(AzureClientSettings.create(settings), repoSettings);
+                .buildClientIfNeeded(azureClientSettings.get("default"), repoSettings).v2();
 
         assertEquals("AZURE_ACCOUNT", client.getAccountName());
 
@@ -131,8 +136,9 @@ class AzureClientProviderTest extends RsaKeyAwareTest {
                         .put("some_settings_2", 210)
                         .build();
 
+        final var azureClientSettings = AzureClientSettings.create(settings);
         final var client = azureClientProvider
-                .buildClientIfNeeded(AzureClientSettings.create(settings), repoSettings);
+                .buildClientIfNeeded(azureClientSettings.get("default"), repoSettings).v2();
 
         assertEquals("AZURE_ACCOUNT", client.getAccountName());
 
@@ -145,13 +151,22 @@ class AzureClientProviderTest extends RsaKeyAwareTest {
     private Settings createSettings() throws IOException  {
         final var secureSettings =
                 new DummySecureSettings()
-                        .setString(AzureClientSettings.AZURE_ACCOUNT.getKey(), "AZURE_ACCOUNT")
-                        .setString(AzureClientSettings.AZURE_ACCOUNT_KEY.getKey(), "AZURE_ACCOUNT_KEY")
-                        .setFile(AzureClientSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
-                        .setFile(AzureClientSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
+                        .setString(
+                                AZURE_ACCOUNT.getConcreteSettingForNamespace("default").getKey(),
+                                "AZURE_ACCOUNT"
+                        ).setString(
+                                AZURE_ACCOUNT_KEY.getConcreteSettingForNamespace("default").getKey(),
+                                "AZURE_ACCOUNT_KEY"
+                        ).setFile(
+                                PUBLIC_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                                Files.newInputStream(publicKeyPem)
+                        ).setFile(
+                                PRIVATE_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                                Files.newInputStream(privateKeyPem)
+                        );
 
         return Settings.builder()
-                .put(AzureClientSettings.MAX_RETRIES.getKey(), 12)
+                .put(AzureClientSettings.MAX_RETRIES.getConcreteSettingForNamespace("default").getKey(), 12)
                 .setSecureSettings(secureSettings)
                 .build();
     }

--- a/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/AbstractRepositoryPlugin.java
+++ b/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/AbstractRepositoryPlugin.java
@@ -20,12 +20,9 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.security.Security;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
@@ -46,9 +43,9 @@ public abstract class AbstractRepositoryPlugin<C, S extends CommonSettings.Clien
 
     private final String repositoryType;
 
-    private final RepositorySettingsProvider<C, S> repositorySettingsProvider;
+    private final String repositorySettingsPrefix;
 
-    private final Set<String> pluginSettingKeys;
+    private final RepositorySettingsProvider<C, S> repositorySettingsProvider;
 
     static {
         try {
@@ -59,11 +56,12 @@ public abstract class AbstractRepositoryPlugin<C, S extends CommonSettings.Clien
     }
 
     protected AbstractRepositoryPlugin(final String repositoryType,
+                                       final String repositorySettingsPrefix,
                                        final Settings settings,
                                        final RepositorySettingsProvider<C, S> repositorySettingsProvider) {
         this.repositoryType = repositoryType;
+        this.repositorySettingsPrefix = repositorySettingsPrefix;
         this.repositorySettingsProvider = repositorySettingsProvider;
-        this.pluginSettingKeys = getSettings().stream().map(Setting::getKey).collect(Collectors.toSet());
         reload(settings);
     }
 
@@ -86,10 +84,9 @@ public abstract class AbstractRepositoryPlugin<C, S extends CommonSettings.Clien
     @Override
     public void reload(final Settings settings) {
         try {
-            final var pluginKeys = settings.filter(pluginSettingKeys::contains);
-            if (!pluginKeys.isEmpty()) {
+            if (!settings.getGroups(repositorySettingsPrefix).isEmpty()) {
                 LOGGER.info("Reload settings for repository type: {}", repositoryType);
-                repositorySettingsProvider.reload(pluginKeys);
+                repositorySettingsProvider.reload(settings);
             }
         } catch (final IOException ioe) {
             throw new UncheckedIOException(ioe);

--- a/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/ClientProvider.java
+++ b/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/ClientProvider.java
@@ -20,7 +20,10 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Objects;
 
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
+
+import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 
 public abstract class ClientProvider<C, S extends CommonSettings.ClientSettings> implements Closeable {
 
@@ -30,18 +33,26 @@ public abstract class ClientProvider<C, S extends CommonSettings.ClientSettings>
 
     protected volatile C client;
 
-    public C buildClientIfNeeded(final S clientSettings, final Settings repositorySettings) throws IOException {
+    private volatile EncryptionKeyProvider encryptionKeyProvider;
+
+    public Tuple<EncryptionKeyProvider, C> buildClientIfNeeded(
+            final S clientSettings,
+            final Settings repositorySettings) throws IOException {
         synchronized (lock) {
             if (Objects.isNull(client)) {
                 client = buildClient(clientSettings, repositorySettings);
+                encryptionKeyProvider =
+                        EncryptionKeyProvider.of(clientSettings.publicKey(), clientSettings.privateKey());
                 previousRepositorySettings = repositorySettings;
             } else if (!previousRepositorySettings.equals(repositorySettings)) {
                 closeClient();
+                encryptionKeyProvider =
+                        EncryptionKeyProvider.of(clientSettings.publicKey(), clientSettings.privateKey());
                 client = buildClient(clientSettings, repositorySettings);
                 previousRepositorySettings = repositorySettings;
             }
         }
-        return client;
+        return Tuple.tuple(encryptionKeyProvider, client);
     }
 
     @Override

--- a/repository-gcs/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsClientSettings.java
+++ b/repository-gcs/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsClientSettings.java
@@ -18,6 +18,9 @@ package io.aiven.elasticsearch.repositories.gcs;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.opensearch.common.settings.SecureSetting;
@@ -30,51 +33,94 @@ import io.aiven.elasticsearch.repositories.CommonSettings;
 import com.google.auth.oauth2.GoogleCredentials;
 
 import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.checkSettings;
-import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.withPrefix;
+import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.getConfigValue;
+import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.readInputStream;
 
 public class GcsClientSettings implements CommonSettings.ClientSettings {
 
-    public static final Setting<InputStream> PUBLIC_KEY_FILE =
-            SecureSetting.secureFile(withPrefix("gcs.public_key_file"), null);
+    static final String GCS_PREFIX = AIVEN_PREFIX + "gcs.";
 
-    public static final Setting<InputStream> PRIVATE_KEY_FILE =
-            SecureSetting.secureFile(withPrefix("gcs.private_key_file"), null);
+    public static final Setting.AffixSetting<InputStream> PUBLIC_KEY_FILE =
+            Setting.affixKeySetting(
+                    GCS_PREFIX,
+                    "public_key_file",
+                    key -> SecureSetting.secureFile(key, null)
+            );
 
-    public static final Setting<InputStream> CREDENTIALS_FILE_SETTING =
-            SecureSetting.secureFile(withPrefix("gcs.client.credentials_file"), null);
+    public static final Setting.AffixSetting<InputStream> PRIVATE_KEY_FILE =
+            Setting.affixKeySetting(
+                    GCS_PREFIX,
+                    "private_key_file",
+                    key -> SecureSetting.secureFile(key, null)
+            );
 
-    public static final Setting<String> PROXY_HOST =
-            Setting.simpleString(withPrefix("gcs.client.proxy.host"), Setting.Property.NodeScope);
+    public static final Setting.AffixSetting<InputStream> CREDENTIALS_FILE_SETTING =
+            Setting.affixKeySetting(
+                    GCS_PREFIX,
+                    "client.credentials_file",
+                    key -> SecureSetting.secureFile(key, null)
+            );
 
-    public static final Setting<Integer> PROXY_PORT =
-            SecureSetting.intSetting(withPrefix("gcs.client.proxy.port"), 0, 0,
-                    Setting.Property.NodeScope);
+    public static final Setting.AffixSetting<String> PROXY_HOST =
+            Setting.affixKeySetting(
+                    GCS_PREFIX,
+                    "client.proxy.host",
+                    key -> Setting.simpleString(key, Setting.Property.NodeScope)
+            );
 
-    public static final Setting<SecureString> PROXY_USER_NAME =
-            SecureSetting.secureString(withPrefix("gcs.client.proxy.user_name"), null);
+    public static final Setting.AffixSetting<Integer> PROXY_PORT =
+            Setting.affixKeySetting(
+                    GCS_PREFIX,
+                    "client.proxy.port",
+                    key -> SecureSetting.intSetting(key, 0, 0, Setting.Property.NodeScope)
+            );
 
-    public static final Setting<SecureString> PROXY_USER_PASSWORD =
-            SecureSetting.secureString(withPrefix("gcs.client.proxy.user_password"), null);
+    public static final Setting.AffixSetting<SecureString> PROXY_USER_NAME =
+            Setting.affixKeySetting(
+                    GCS_PREFIX,
+                    "client.proxy.user_name",
+                    key -> SecureSetting.secureString(key, null)
+            );
 
-    public static final Setting<String> PROJECT_ID =
-            Setting.simpleString(withPrefix("gcs.client.project_id"), Setting.Property.NodeScope);
+    public static final Setting.AffixSetting<SecureString> PROXY_USER_PASSWORD =
+            Setting.affixKeySetting(
+                    GCS_PREFIX,
+                    "client.proxy.user_password",
+                    key -> SecureSetting.secureString(key, null)
+            );
 
-    public static final Setting<Integer> CONNECTION_TIMEOUT =
-            Setting.intSetting(withPrefix("gcs.client.connection_timeout"), -1, -1,
-                    Setting.Property.NodeScope);
+    public static final Setting.AffixSetting<String> PROJECT_ID =
+            Setting.affixKeySetting(
+                    GCS_PREFIX,
+                    "client.project_id",
+                    key -> Setting.simpleString(key, Setting.Property.NodeScope)
+            );
 
-    public static final Setting<Integer> READ_TIMEOUT =
-            Setting.intSetting(withPrefix("gcs.client.read_timeout"), -1, -1,
-                    Setting.Property.NodeScope);
+    public static final Setting.AffixSetting<Integer> CONNECTION_TIMEOUT =
+            Setting.affixKeySetting(
+                    GCS_PREFIX,
+                    "client.connection_timeout",
+                    key -> Setting.intSetting(key, -1, -1, Setting.Property.NodeScope)
+            );
+
+    public static final Setting.AffixSetting<Integer> READ_TIMEOUT =
+            Setting.affixKeySetting(
+                    GCS_PREFIX,
+                    "client.read_timeout",
+                    key -> Setting.intSetting(key, -1, -1, Setting.Property.NodeScope)
+            );
 
     /** The number of retries to use when an GCS request fails. */
-    public static final Setting<Integer> MAX_RETRIES_SETTING =
-            Setting.intSetting(withPrefix("gcs.client.max_retries"), 3, 0, 
-                    Setting.Property.NodeScope);
+    public static final Setting.AffixSetting<Integer> MAX_RETRIES_SETTING =
+            Setting.affixKeySetting(
+                    GCS_PREFIX,
+                    "client.max_retries",
+                    key -> Setting.intSetting(key, 3, 0, Setting.Property.NodeScope)
+            );
 
-    private final InputStream publicKey;
+    private final byte[] publicKey;
 
-    private final InputStream privateKey;
+    private final byte[] privateKey;
 
     private final String projectId;
 
@@ -95,8 +141,8 @@ public class GcsClientSettings implements CommonSettings.ClientSettings {
 
     private final int proxyPort;
 
-    private GcsClientSettings(final InputStream publicKey,
-                              final InputStream privateKey,
+    private GcsClientSettings(final byte[] publicKey,
+                              final byte[] privateKey,
                               final String projectId,
                               final GoogleCredentials gcsCredentials,
                               final int connectionTimeout,
@@ -119,41 +165,57 @@ public class GcsClientSettings implements CommonSettings.ClientSettings {
         this.proxyUserPassword = proxyUserPassword;
     }
 
-    public static GcsClientSettings create(final Settings settings) throws IOException {
+    public static Map<String, GcsClientSettings> create(final Settings settings) throws IOException {
         if (settings.isEmpty()) {
             throw new IllegalArgumentException("Settings for GC storage hasn't been set");
         }
-        checkSettings(CREDENTIALS_FILE_SETTING, settings);
-        checkSettings(PUBLIC_KEY_FILE, settings);
-        checkSettings(PRIVATE_KEY_FILE, settings);
-        if (PROXY_PORT.exists(settings) && PROXY_PORT.get(settings) < 0) {
+        final Set<String> clientNames = settings.getGroups(GCS_PREFIX).keySet();
+        final var clientSettings = new HashMap<String, GcsClientSettings>();
+        for (final var clientName : clientNames) {
+            clientSettings.put(clientName, createSettings(clientName, settings));
+        }
+        return Map.copyOf(clientSettings);
+    }
+
+    private static GcsClientSettings createSettings(
+            final String clientName, final Settings settings) throws IOException {
+        checkSettings(CREDENTIALS_FILE_SETTING, clientName, settings);
+        checkSettings(PUBLIC_KEY_FILE, clientName, settings);
+        checkSettings(PRIVATE_KEY_FILE, clientName, settings);
+        if (PROXY_PORT.getConcreteSettingForNamespace(clientName).exists(settings)
+                && PROXY_PORT.getConcreteSettingForNamespace(clientName).get(settings) < 0) {
             throw new IllegalArgumentException("Settings with name " + PROXY_PORT.getKey() + " must be greater than 0");
         }
         return new GcsClientSettings(
-                PUBLIC_KEY_FILE.get(settings),
-                PRIVATE_KEY_FILE.get(settings),
-                PROJECT_ID.get(settings),
-                loadCredentials(settings),
-                CONNECTION_TIMEOUT.get(settings),
-                READ_TIMEOUT.get(settings),
-                MAX_RETRIES_SETTING.get(settings),
-                PROXY_HOST.get(settings),
-                PROXY_PORT.get(settings),
-                PROXY_USER_NAME.get(settings).toString(),
-                PROXY_USER_PASSWORD.get(settings).getChars());
+                readInputStream(getConfigValue(settings, clientName, PUBLIC_KEY_FILE)),
+                readInputStream(getConfigValue(settings, clientName, PRIVATE_KEY_FILE)),
+                getConfigValue(settings, clientName, PROJECT_ID),
+                loadCredentials(settings, clientName),
+                getConfigValue(settings, clientName, CONNECTION_TIMEOUT),
+                getConfigValue(settings, clientName, READ_TIMEOUT),
+                getConfigValue(settings, clientName, MAX_RETRIES_SETTING),
+                getConfigValue(settings, clientName, PROXY_HOST),
+                getConfigValue(settings, clientName, PROXY_PORT),
+                getConfigValue(settings, clientName, PROXY_USER_NAME).toString(),
+                getConfigValue(settings, clientName, PROXY_USER_PASSWORD).getChars()
+        );
     }
 
-    private static GoogleCredentials loadCredentials(final Settings settings) throws IOException {
-        try (final var in = CREDENTIALS_FILE_SETTING.get(settings)) {
+    private static GoogleCredentials loadCredentials(
+            final Settings settings,
+            final String clientName) throws IOException {
+        try (final var in = getConfigValue(settings, clientName, CREDENTIALS_FILE_SETTING)) {
             return GoogleCredentials.fromStream(in);
         }
     }
 
-    public InputStream publicKey() {
+    @Override
+    public byte[] publicKey() {
         return publicKey;
     }
 
-    public InputStream privateKey() {
+    @Override
+    public byte[] privateKey() {
         return privateKey;
     }
 

--- a/repository-gcs/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsRepositoryPlugin.java
+++ b/repository-gcs/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsRepositoryPlugin.java
@@ -25,12 +25,14 @@ import io.aiven.elasticsearch.repositories.AbstractRepositoryPlugin;
 
 import com.google.cloud.storage.Storage;
 
+import static io.aiven.elasticsearch.repositories.gcs.GcsClientSettings.GCS_PREFIX;
+
 public class GcsRepositoryPlugin extends AbstractRepositoryPlugin<Storage, GcsClientSettings>  {
 
     public static final String REPOSITORY_TYPE = "aiven-gcs";
 
     public GcsRepositoryPlugin(final Settings settings) {
-        super(REPOSITORY_TYPE, settings, new GcsSettingsProvider());
+        super(REPOSITORY_TYPE, GCS_PREFIX, settings, new GcsSettingsProvider());
     }
 
     @Override

--- a/repository-gcs/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsRepositoryStorageIOProvider.java
+++ b/repository-gcs/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsRepositoryStorageIOProvider.java
@@ -37,7 +37,6 @@ import io.aiven.elasticsearch.repositories.CommonSettings;
 import io.aiven.elasticsearch.repositories.Permissions;
 import io.aiven.elasticsearch.repositories.RepositoryStorageIOProvider;
 import io.aiven.elasticsearch.repositories.io.CryptoIOProvider;
-import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 
 import com.google.cloud.BatchResult;
 import com.google.cloud.storage.Blob;
@@ -65,9 +64,8 @@ public class GcsRepositoryStorageIOProvider
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GcsRepositoryStorageIOProvider.class);
 
-    public GcsRepositoryStorageIOProvider(final GcsClientSettings storageSettings,
-                                          final EncryptionKeyProvider encryptionKeyProvider) {
-        super(new GcsClientProvider(), storageSettings, encryptionKeyProvider);
+    public GcsRepositoryStorageIOProvider(final Map<String, GcsClientSettings> storageSettings) {
+        super(new GcsClientProvider(), storageSettings);
     }
 
     @Override

--- a/repository-gcs/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsSettingsProvider.java
+++ b/repository-gcs/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsSettingsProvider.java
@@ -23,7 +23,6 @@ import org.opensearch.common.settings.Settings;
 import io.aiven.elasticsearch.repositories.Permissions;
 import io.aiven.elasticsearch.repositories.RepositorySettingsProvider;
 import io.aiven.elasticsearch.repositories.RepositoryStorageIOProvider;
-import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 
 import com.google.cloud.storage.Storage;
 
@@ -32,14 +31,10 @@ public class GcsSettingsProvider extends RepositorySettingsProvider<Storage, Gcs
     @Override
     protected RepositoryStorageIOProvider<Storage, GcsClientSettings> createRepositoryStorageIOProvider(
             final Settings settings) throws IOException {
+
         return Permissions.doPrivileged(() -> {
             final var gcsClientSettings = GcsClientSettings.create(settings);
-            final var encryptionKeyProvider =
-                    EncryptionKeyProvider.of(
-                            gcsClientSettings.publicKey().readAllBytes(),
-                            gcsClientSettings.privateKey().readAllBytes()
-                    );
-            return new GcsRepositoryStorageIOProvider(gcsClientSettings, encryptionKeyProvider);
+            return new GcsRepositoryStorageIOProvider(gcsClientSettings);
         });
     }
 

--- a/repository-gcs/src/test/java/io/aiven/elasticsearch/repositories/gcs/GcsClientProviderTest.java
+++ b/repository-gcs/src/test/java/io/aiven/elasticsearch/repositories/gcs/GcsClientProviderTest.java
@@ -48,9 +48,9 @@ class GcsClientProviderTest extends RsaKeyAwareTest {
         final var gcsClientProvider = new GcsClientProvider();
         final var settings = Settings.builder()
                 .put(CommonSettings.RepositorySettings.BASE_PATH.getKey(), "base_path/")
-                .put(GcsClientSettings.CONNECTION_TIMEOUT.getKey(), 1)
-                .put(GcsClientSettings.READ_TIMEOUT.getKey(), 2)
-                .put(GcsClientSettings.PROJECT_ID.getKey(), "some_project")
+                .put(GcsClientSettings.CONNECTION_TIMEOUT.getConcreteSettingForNamespace("default").getKey(), 1)
+                .put(GcsClientSettings.READ_TIMEOUT.getConcreteSettingForNamespace("default").getKey(), 2)
+                .put(GcsClientSettings.PROJECT_ID.getConcreteSettingForNamespace("default").getKey(), "some_project")
                 .setSecureSettings(createFullSecureSettings()).build();
 
         final var repoSettings =
@@ -58,7 +58,11 @@ class GcsClientProviderTest extends RsaKeyAwareTest {
                         .put("some_settings_1", 20)
                         .put("some_settings_2", 210)
                         .build();
-        final var client = gcsClientProvider.buildClientIfNeeded(GcsClientSettings.create(settings), repoSettings);
+        final var client =
+                gcsClientProvider.buildClientIfNeeded(
+                        GcsClientSettings.create(settings).get("default"),
+                        repoSettings
+                ).v2();
 
         assertTrue(client.getOptions().getTransportOptions() instanceof HttpTransportOptions);
         final var httpTransportOptions = (HttpTransportOptions) client.getOptions().getTransportOptions();
@@ -76,11 +80,11 @@ class GcsClientProviderTest extends RsaKeyAwareTest {
         final var gcsClientProvider = new GcsClientProvider();
         final var proxySettingsWithUsernameAndPassword = Settings.builder()
                 .put(CommonSettings.RepositorySettings.BASE_PATH.getKey(), "base_path/")
-                .put(GcsClientSettings.CONNECTION_TIMEOUT.getKey(), 1)
-                .put(GcsClientSettings.READ_TIMEOUT.getKey(), 2)
-                .put(GcsClientSettings.PROXY_HOST.getKey(), "socks.test.io")
-                .put(GcsClientSettings.PROXY_PORT.getKey(), 1234)
-                .put(GcsClientSettings.PROJECT_ID.getKey(), "some_project")
+                .put(GcsClientSettings.CONNECTION_TIMEOUT.getConcreteSettingForNamespace("default").getKey(), 1)
+                .put(GcsClientSettings.READ_TIMEOUT.getConcreteSettingForNamespace("default").getKey(), 2)
+                .put(GcsClientSettings.PROXY_HOST.getConcreteSettingForNamespace("default").getKey(), "socks.test.io")
+                .put(GcsClientSettings.PROXY_PORT.getConcreteSettingForNamespace("default").getKey(), 1234)
+                .put(GcsClientSettings.PROJECT_ID.getConcreteSettingForNamespace("default").getKey(), "some_project")
                 .setSecureSettings(createFullSecureSettingsWithProxyUsernameAndPassword()).build();
         final var repoSettings =
                 Settings.builder()
@@ -89,7 +93,10 @@ class GcsClientProviderTest extends RsaKeyAwareTest {
                         .build();
 
         final var client = gcsClientProvider
-                .buildClientIfNeeded(GcsClientSettings.create(proxySettingsWithUsernameAndPassword), repoSettings);
+                .buildClientIfNeeded(
+                        GcsClientSettings.create(proxySettingsWithUsernameAndPassword).get("default"),
+                        repoSettings
+                ).v2();
 
         assertTrue(client.getOptions().getTransportOptions() instanceof HttpTransportOptions);
 
@@ -115,11 +122,11 @@ class GcsClientProviderTest extends RsaKeyAwareTest {
         final var gcsClientProvider = new GcsClientProvider();
         final var proxySettingsWithoutUsernameAndPassword = Settings.builder()
                 .put(CommonSettings.RepositorySettings.BASE_PATH.getKey(), "base_path/")
-                .put(GcsClientSettings.CONNECTION_TIMEOUT.getKey(), 1)
-                .put(GcsClientSettings.READ_TIMEOUT.getKey(), 2)
-                .put(GcsClientSettings.PROXY_HOST.getKey(), "socks5.test.io")
-                .put(GcsClientSettings.PROXY_PORT.getKey(), 12345)
-                .put(GcsClientSettings.PROJECT_ID.getKey(), "some_project")
+                .put(GcsClientSettings.CONNECTION_TIMEOUT.getConcreteSettingForNamespace("default").getKey(), 1)
+                .put(GcsClientSettings.READ_TIMEOUT.getConcreteSettingForNamespace("default").getKey(), 2)
+                .put(GcsClientSettings.PROXY_HOST.getConcreteSettingForNamespace("default").getKey(), "socks5.test.io")
+                .put(GcsClientSettings.PROXY_PORT.getConcreteSettingForNamespace("default").getKey(), 12345)
+                .put(GcsClientSettings.PROJECT_ID.getConcreteSettingForNamespace("default").getKey(), "some_project")
                 .setSecureSettings(createFullSecureSettings()).build();
         final var repoSettings =
                 Settings.builder()
@@ -127,7 +134,10 @@ class GcsClientProviderTest extends RsaKeyAwareTest {
                         .put("some_settings_2", 210)
                         .build();
         final var client = gcsClientProvider
-                .buildClientIfNeeded(GcsClientSettings.create(proxySettingsWithoutUsernameAndPassword), repoSettings);
+                .buildClientIfNeeded(
+                        GcsClientSettings.create(proxySettingsWithoutUsernameAndPassword).get("default"),
+                        repoSettings
+                ).v2();
 
         assertTrue(client.getOptions().getTransportOptions() instanceof HttpTransportOptions);
 
@@ -160,7 +170,10 @@ class GcsClientProviderTest extends RsaKeyAwareTest {
                         .build();
 
         final var client = gcsClientProvider
-                .buildClientIfNeeded(GcsClientSettings.create(settings), repoSettings);
+                .buildClientIfNeeded(
+                        GcsClientSettings.create(settings).get("default"),
+                        repoSettings
+                ).v2();
         assertNotNull(client);
         assertTrue(client.getOptions().getTransportOptions() instanceof HttpTransportOptions);
 
@@ -186,7 +199,10 @@ class GcsClientProviderTest extends RsaKeyAwareTest {
                         .build();
 
         final var client = gcsClientProvider
-                .buildClientIfNeeded(GcsClientSettings.create(settings), repoSettings);
+                .buildClientIfNeeded(
+                        GcsClientSettings.create(settings).get("default"),
+                        repoSettings
+                ).v2();
         assertNotNull(client);
         assertTrue(client.getOptions().getTransportOptions() instanceof HttpTransportOptions);
 
@@ -216,43 +232,67 @@ class GcsClientProviderTest extends RsaKeyAwareTest {
     private DummySecureSettings createFullSecureSettings() throws IOException {
         return new DummySecureSettings()
                 .setFile(
-                        GcsClientSettings.CREDENTIALS_FILE_SETTING.getKey(),
-                        getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json"))
-                .setFile(GcsClientSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem))
-                .setFile(GcsClientSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem));
+                        GcsClientSettings.CREDENTIALS_FILE_SETTING.getConcreteSettingForNamespace("default").getKey(),
+                        getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json")
+                ).setFile(
+                        GcsClientSettings.PRIVATE_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                        Files.newInputStream(privateKeyPem)
+                ).setFile(
+                        GcsClientSettings.PUBLIC_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                        Files.newInputStream(publicKeyPem)
+                );
     }
 
     private DummySecureSettings createFullSecureSettingsWithProxyUsernameAndPassword() throws IOException {
         return new DummySecureSettings()
                 .setFile(
-                        GcsClientSettings.CREDENTIALS_FILE_SETTING.getKey(),
-                        getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json"))
-                .setFile(GcsClientSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem))
-                .setFile(GcsClientSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
-                .setString(GcsClientSettings.PROXY_USER_NAME.getKey(), "some_user_name")
-                .setString(GcsClientSettings.PROXY_USER_PASSWORD.getKey(), "some_user_password");
+                        GcsClientSettings.CREDENTIALS_FILE_SETTING.getConcreteSettingForNamespace("default").getKey(),
+                        getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json")
+                ).setFile(
+                        GcsClientSettings.PRIVATE_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                        Files.newInputStream(privateKeyPem)
+                ).setFile(
+                        GcsClientSettings.PUBLIC_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                        Files.newInputStream(publicKeyPem)
+                ).setString(
+                        GcsClientSettings.PROXY_USER_NAME.getConcreteSettingForNamespace("default").getKey(),
+                        "some_user_name"
+                ).setString(
+                        GcsClientSettings.PROXY_USER_PASSWORD.getConcreteSettingForNamespace("default").getKey(),
+                        "some_user_password"
+                );
     }
 
     private DummySecureSettings createNoGcsCredentialFileSettings() throws IOException {
         return new DummySecureSettings()
-                .setFile(GcsClientSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
-                .setFile(GcsClientSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
+                .setFile(
+                        GcsClientSettings.PUBLIC_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                        Files.newInputStream(publicKeyPem)
+                ).setFile(
+                        GcsClientSettings.PRIVATE_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                        Files.newInputStream(privateKeyPem)
+                );
     }
 
     private DummySecureSettings createPublicRsaKeyOnlySecureSettings() throws IOException {
         return new DummySecureSettings()
                 .setFile(
-                        GcsClientSettings.CREDENTIALS_FILE_SETTING.getKey(),
-                        getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json"))
-                .setFile(GcsClientSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem));
+                        GcsClientSettings.CREDENTIALS_FILE_SETTING.getConcreteSettingForNamespace("default").getKey(),
+                        getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json")
+                ).setFile(
+                        GcsClientSettings.PUBLIC_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                        Files.newInputStream(publicKeyPem));
     }
 
     private DummySecureSettings createPrivateRsaKeyOnlySecureSettings() throws IOException {
         return new DummySecureSettings()
                 .setFile(
-                        GcsClientSettings.CREDENTIALS_FILE_SETTING.getKey(),
-                        getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json"))
-                .setFile(GcsClientSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
+                        GcsClientSettings.CREDENTIALS_FILE_SETTING.getConcreteSettingForNamespace("default").getKey(),
+                        getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json")
+                ).setFile(
+                        GcsClientSettings.PRIVATE_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                        Files.newInputStream(privateKeyPem)
+                );
     }
 
     GoogleCredentials loadCredentials() throws IOException {

--- a/repository-gcs/src/test/java/io/aiven/elasticsearch/repositories/gcs/GcsClientSettingsTest.java
+++ b/repository-gcs/src/test/java/io/aiven/elasticsearch/repositories/gcs/GcsClientSettingsTest.java
@@ -36,16 +36,37 @@ class GcsClientSettingsTest extends RsaKeyAwareTest {
 
     @Test
     void loadSettings() throws Exception {
-        final var settings = createSettings()
+        final var settings = createSettings("default")
                 .setSecureSettings(
                         createSecureSettings(
+                                "default",
                                 getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json"),
                                 Files.newInputStream(publicKeyPem),
                                 Files.newInputStream(privateKeyPem)
                         )
                 ).build();
 
-        final var gcsClientSettings = GcsClientSettings.create(settings);
+        final var gcsClientSettings = GcsClientSettings.create(settings).get("default");
+        assertEquals("some_project", gcsClientSettings.projectId());
+        assertEquals(1, gcsClientSettings.connectionTimeout());
+        assertEquals(2, gcsClientSettings.readTimeout());
+
+        assertNotNull(gcsClientSettings.gcsCredentials());
+    }
+
+    @Test
+    void loadNonDefaultClientSettings() throws IOException {
+        final var settings = createSettings("some_client")
+                .setSecureSettings(
+                        createSecureSettings(
+                                "some_client",
+                                getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json"),
+                                Files.newInputStream(publicKeyPem),
+                                Files.newInputStream(privateKeyPem)
+                        )
+                ).build();
+
+        final var gcsClientSettings = GcsClientSettings.create(settings).get("some_client");
         assertEquals("some_project", gcsClientSettings.projectId());
         assertEquals(1, gcsClientSettings.connectionTimeout());
         assertEquals(2, gcsClientSettings.readTimeout());
@@ -65,20 +86,28 @@ class GcsClientSettingsTest extends RsaKeyAwareTest {
         );
     }
 
-    Settings.Builder createSettings() {
+    Settings.Builder createSettings(final String clientName) {
         return Settings.builder()
-                .put(GcsClientSettings.CONNECTION_TIMEOUT.getKey(), 1)
-                .put(GcsClientSettings.READ_TIMEOUT.getKey(), 2)
-                .put(GcsClientSettings.PROJECT_ID.getKey(), "some_project");
+                .put(GcsClientSettings.CONNECTION_TIMEOUT.getConcreteSettingForNamespace(clientName).getKey(), 1)
+                .put(GcsClientSettings.READ_TIMEOUT.getConcreteSettingForNamespace(clientName).getKey(), 2)
+                .put(GcsClientSettings.PROJECT_ID.getConcreteSettingForNamespace(clientName).getKey(), "some_project");
     }
 
-    SecureSettings createSecureSettings(final InputStream googleCredential,
+    SecureSettings createSecureSettings(final String clientName,
+                                        final InputStream googleCredential,
                                         final InputStream publicKey,
                                         final InputStream privateKey) throws IOException {
         return new DummySecureSettings()
-                .setFile(GcsClientSettings.CREDENTIALS_FILE_SETTING.getKey(), googleCredential)
-                .setFile(GcsClientSettings.PUBLIC_KEY_FILE.getKey(), publicKey)
-                .setFile(GcsClientSettings.PRIVATE_KEY_FILE.getKey(), privateKey);
+                .setFile(
+                        GcsClientSettings.CREDENTIALS_FILE_SETTING.getConcreteSettingForNamespace(clientName).getKey(),
+                        googleCredential
+                ).setFile(
+                        GcsClientSettings.PUBLIC_KEY_FILE.getConcreteSettingForNamespace(clientName).getKey(),
+                        publicKey
+                ).setFile(
+                        GcsClientSettings.PRIVATE_KEY_FILE.getConcreteSettingForNamespace(clientName).getKey(),
+                        privateKey
+                );
 
     }
 

--- a/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -18,6 +18,9 @@ package io.aiven.elasticsearch.repositories.s3;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import org.opensearch.common.settings.SecureSetting;
 import org.opensearch.common.settings.SecureString;
@@ -32,43 +35,72 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 
 import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.checkSettings;
+import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.getConfigValue;
 import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.readInputStream;
-import static io.aiven.elasticsearch.repositories.CommonSettings.ClientSettings.withPrefix;
 
 public class S3ClientSettings implements ClientSettings {
 
-    public static final Setting<InputStream> PUBLIC_KEY_FILE =
-            SecureSetting.secureFile(withPrefix("s3.public_key_file"), null);
+    static final String S3_PREFIX = AIVEN_PREFIX + "s3.";
 
-    public static final Setting<InputStream> PRIVATE_KEY_FILE =
-            SecureSetting.secureFile(withPrefix("s3.private_key_file"), null);
+    public static final Setting.AffixSetting<InputStream> PUBLIC_KEY_FILE =
+            Setting.affixKeySetting(
+                    S3_PREFIX,
+                    "public_key_file",
+                    key -> SecureSetting.secureFile(key, null)
+            );
 
-    public static final Setting<SecureString> AWS_SECRET_ACCESS_KEY =
-            SecureSetting.secureString(withPrefix("s3.client.aws_secret_access_key"), null);
+    public static final Setting.AffixSetting<InputStream> PRIVATE_KEY_FILE =
+            Setting.affixKeySetting(
+                    S3_PREFIX,
+                    "private_key_file",
+                    key -> SecureSetting.secureFile(key, null)
+            );
 
-    public static final Setting<SecureString> AWS_ACCESS_KEY_ID =
-            SecureSetting.secureString(withPrefix("s3.client.aws_access_key_id"), null);
+    public static final Setting.AffixSetting<SecureString> AWS_SECRET_ACCESS_KEY =
+            Setting.affixKeySetting(
+                    S3_PREFIX,
+                    "client.aws_secret_access_key",
+                    key -> SecureSetting.secureString(key, null)
+            );
 
-    public static final Setting<SecureString> ENDPOINT =
-            SecureSetting.secureString(withPrefix("s3.client.endpoint"), null);
+    public static final Setting.AffixSetting<SecureString> AWS_ACCESS_KEY_ID =
+            Setting.affixKeySetting(
+                    S3_PREFIX,
+                    "client.aws_access_key_id",
+                    key -> SecureSetting.secureString(key, null)
+            );
 
-    public static final Setting<Integer> MAX_RETRIES =
-            Setting.intSetting(
-                    withPrefix("s3.client.max_retries"),
-                    ClientConfiguration.DEFAULT_RETRY_POLICY.getMaxErrorRetry(),
-                    Setting.Property.NodeScope);
+    public static final Setting.AffixSetting<SecureString> ENDPOINT =
+            Setting.affixKeySetting(
+                    S3_PREFIX,
+                    "client.endpoint",
+                    key -> SecureSetting.secureString(key, null)
+            );
 
-    public static final Setting<Boolean> USE_THROTTLE_RETRIES =
-            Setting.boolSetting(
-                    withPrefix("s3.client.use_throttle_retries"),
-                    ClientConfiguration.DEFAULT_THROTTLE_RETRIES,
-                    Setting.Property.NodeScope);
+    public static final Setting.AffixSetting<Integer> MAX_RETRIES =
+            Setting.affixKeySetting(
+                    S3_PREFIX,
+                    "client.max_retries",
+                    key -> Setting.intSetting(key,
+                            ClientConfiguration.DEFAULT_RETRY_POLICY.getMaxErrorRetry(), Setting.Property.NodeScope)
+            );
 
-    public static final Setting<TimeValue> READ_TIMEOUT =
-            Setting.timeSetting(
-                    withPrefix("s3.client.read_timeout"),
-                    TimeValue.timeValueMillis(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT),
-                    Setting.Property.NodeScope);
+    public static final Setting.AffixSetting<Boolean> USE_THROTTLE_RETRIES =
+            Setting.affixKeySetting(
+                    S3_PREFIX,
+                    "client.use_throttle_retries",
+                    key -> Setting.boolSetting(key,
+                            ClientConfiguration.DEFAULT_THROTTLE_RETRIES, Setting.Property.NodeScope)
+            );
+
+    public static final Setting.AffixSetting<TimeValue> READ_TIMEOUT =
+            Setting.affixKeySetting(
+                    S3_PREFIX,
+                    "client.read_timeout",
+                    key -> Setting.timeSetting(key,
+                            TimeValue.timeValueMillis(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT),
+                            Setting.Property.NodeScope)
+            );
 
     private final byte[] publicKey;
 
@@ -101,10 +133,12 @@ public class S3ClientSettings implements ClientSettings {
         this.readTimeout = readTimeout;
     }
 
+    @Override
     public byte[] publicKey() {
         return publicKey;
     }
 
+    @Override
     public byte[] privateKey() {
         return privateKey;
     }
@@ -129,26 +163,36 @@ public class S3ClientSettings implements ClientSettings {
         return Math.toIntExact(readTimeout);
     }
 
-    public static S3ClientSettings create(final Settings settings) throws IOException {
+    public static Map<String, S3ClientSettings> create(final Settings settings) throws IOException {
         if (settings.isEmpty()) {
             throw new IllegalArgumentException("Settings for AWS S3 haven't been set");
         }
-        checkSettings(AWS_ACCESS_KEY_ID, settings);
-        checkSettings(AWS_SECRET_ACCESS_KEY, settings);
-        checkSettings(ENDPOINT, settings);
-        checkSettings(PUBLIC_KEY_FILE, settings);
-        checkSettings(PRIVATE_KEY_FILE, settings);
+        final Set<String> clientNames = settings.getGroups(S3_PREFIX).keySet();
+        final var clientSettings = new HashMap<String, S3ClientSettings>();
+        for (final var clientName : clientNames) {
+            clientSettings.put(clientName, createSettings(clientName, settings));
+        }
+        return Map.copyOf(clientSettings);
+    }
+
+    static S3ClientSettings createSettings(final String clientName, final Settings settings) throws IOException {
+        checkSettings(AWS_ACCESS_KEY_ID, clientName, settings);
+        checkSettings(AWS_SECRET_ACCESS_KEY, clientName, settings);
+        checkSettings(ENDPOINT, clientName, settings);
+        checkSettings(PUBLIC_KEY_FILE, clientName, settings);
+        checkSettings(PRIVATE_KEY_FILE, clientName, settings);
         return new S3ClientSettings(
-                readInputStream(PUBLIC_KEY_FILE, settings),
-                readInputStream(PRIVATE_KEY_FILE, settings),
+                readInputStream(getConfigValue(settings, clientName, PUBLIC_KEY_FILE)),
+                readInputStream(getConfigValue(settings, clientName, PRIVATE_KEY_FILE)),
                 new BasicAWSCredentials(
-                        AWS_ACCESS_KEY_ID.get(settings).toString(),
-                        AWS_SECRET_ACCESS_KEY.get(settings).toString()
+                        getConfigValue(settings, clientName, AWS_ACCESS_KEY_ID).toString(),
+                        getConfigValue(settings, clientName, AWS_SECRET_ACCESS_KEY).toString()
                 ),
-                ENDPOINT.get(settings).toString(),
-                MAX_RETRIES.get(settings),
-                USE_THROTTLE_RETRIES.get(settings),
-                READ_TIMEOUT.get(settings).millis());
+                getConfigValue(settings, clientName, ENDPOINT).toString(),
+                getConfigValue(settings, clientName, MAX_RETRIES),
+                getConfigValue(settings, clientName, USE_THROTTLE_RETRIES),
+                getConfigValue(settings, clientName, READ_TIMEOUT).millis()
+        );
     }
 
 }

--- a/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -28,12 +28,14 @@ import io.aiven.elasticsearch.repositories.Permissions;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 
+import static io.aiven.elasticsearch.repositories.s3.S3ClientSettings.S3_PREFIX;
+
 public class S3RepositoryPlugin extends AbstractRepositoryPlugin<AmazonS3Client, S3ClientSettings> {
 
     public static final String REPOSITORY_TYPE = "aiven-s3";
 
     public S3RepositoryPlugin(final Settings settings) {
-        super(REPOSITORY_TYPE, settings, new S3SettingsProvider());
+        super(REPOSITORY_TYPE, S3_PREFIX, settings, new S3SettingsProvider());
     }
 
     @Override

--- a/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3RepositoryStorageIOProvider.java
+++ b/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3RepositoryStorageIOProvider.java
@@ -35,7 +35,6 @@ import io.aiven.elasticsearch.repositories.CommonSettings;
 import io.aiven.elasticsearch.repositories.Permissions;
 import io.aiven.elasticsearch.repositories.RepositoryStorageIOProvider;
 import io.aiven.elasticsearch.repositories.io.CryptoIOProvider;
-import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -64,9 +63,8 @@ public class S3RepositoryStorageIOProvider extends RepositoryStorageIOProvider<A
                     Setting.Property.NodeScope,
                     Setting.Property.Dynamic);
 
-    public S3RepositoryStorageIOProvider(final S3ClientSettings clientSettings,
-                                         final EncryptionKeyProvider encryptionKeyProvider) {
-        super(new S3ClientProvider(), clientSettings, encryptionKeyProvider);
+    public S3RepositoryStorageIOProvider(final Map<String, S3ClientSettings> clientSettings) {
+        super(new S3ClientProvider(), clientSettings);
     }
 
     @Override

--- a/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3SettingsProvider.java
+++ b/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3SettingsProvider.java
@@ -23,7 +23,6 @@ import org.opensearch.common.settings.Settings;
 import io.aiven.elasticsearch.repositories.Permissions;
 import io.aiven.elasticsearch.repositories.RepositorySettingsProvider;
 import io.aiven.elasticsearch.repositories.RepositoryStorageIOProvider;
-import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 
@@ -34,9 +33,7 @@ public class S3SettingsProvider extends RepositorySettingsProvider<AmazonS3Clien
             final Settings settings) throws IOException {
         return Permissions.doPrivileged(() -> {
             final var s3ClientSettings = S3ClientSettings.create(settings);
-            final var encryptionKeyProvider =
-                    EncryptionKeyProvider.of(s3ClientSettings.publicKey(), s3ClientSettings.privateKey());
-            return new S3RepositoryStorageIOProvider(s3ClientSettings, encryptionKeyProvider);
+            return new S3RepositoryStorageIOProvider(s3ClientSettings);
         });
     }
 

--- a/repository-s3/src/test/java/io/aiven/elasticsearch/repositories/s3/S3ClientProviderTest.java
+++ b/repository-s3/src/test/java/io/aiven/elasticsearch/repositories/s3/S3ClientProviderTest.java
@@ -33,6 +33,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.support.ReflectionSupport;
 
+import static io.aiven.elasticsearch.repositories.s3.S3ClientSettings.AWS_ACCESS_KEY_ID;
+import static io.aiven.elasticsearch.repositories.s3.S3ClientSettings.AWS_SECRET_ACCESS_KEY;
+import static io.aiven.elasticsearch.repositories.s3.S3ClientSettings.ENDPOINT;
+import static io.aiven.elasticsearch.repositories.s3.S3ClientSettings.MAX_RETRIES;
+import static io.aiven.elasticsearch.repositories.s3.S3ClientSettings.PRIVATE_KEY_FILE;
+import static io.aiven.elasticsearch.repositories.s3.S3ClientSettings.PUBLIC_KEY_FILE;
+import static io.aiven.elasticsearch.repositories.s3.S3ClientSettings.READ_TIMEOUT;
+import static io.aiven.elasticsearch.repositories.s3.S3ClientSettings.USE_THROTTLE_RETRIES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -52,17 +60,29 @@ class S3ClientProviderTest extends RsaKeyAwareTest {
 
         final var secureSettings =
                 new DummySecureSettings()
-                        .setString(S3ClientSettings.AWS_ACCESS_KEY_ID.getKey(), "AWS_ACCESS_KEY_ID")
-                        .setString(S3ClientSettings.AWS_SECRET_ACCESS_KEY.getKey(), "AWS_SECRET_ACCESS_KEY")
-                        .setString(S3ClientSettings.ENDPOINT.getKey(), "http://endpoint")
-                        .setFile(S3ClientSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
-                        .setFile(S3ClientSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
+                        .setString(
+                                AWS_ACCESS_KEY_ID.getConcreteSettingForNamespace("default").getKey(),
+                                "AWS_ACCESS_KEY_ID"
+                        ).setString(
+                                AWS_SECRET_ACCESS_KEY.getConcreteSettingForNamespace("default").getKey(),
+                                "AWS_SECRET_ACCESS_KEY")
+                        .setString(
+                                ENDPOINT.getConcreteSettingForNamespace("default").getKey(),
+                                "http://endpoint"
+                        ).setFile(
+                                PUBLIC_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                                Files.newInputStream(publicKeyPem)
+                        ).setFile(
+                                PRIVATE_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                                Files.newInputStream(privateKeyPem)
+                        );
 
         final var settings =
                 Settings.builder()
-                        .put(S3ClientSettings.MAX_RETRIES.getKey(), 12)
-                        .put(S3ClientSettings.READ_TIMEOUT.getKey(), TimeValue.timeValueMillis(1000L))
-                        .put(S3ClientSettings.USE_THROTTLE_RETRIES.getKey(), false)
+                        .put(MAX_RETRIES.getConcreteSettingForNamespace("default").getKey(), 12)
+                        .put(READ_TIMEOUT.getConcreteSettingForNamespace("default").getKey(),
+                                TimeValue.timeValueMillis(1000L))
+                        .put(USE_THROTTLE_RETRIES.getConcreteSettingForNamespace("default").getKey(), false)
                         .setSecureSettings(secureSettings)
                         .build();
         final var repoSettings =
@@ -71,7 +91,11 @@ class S3ClientProviderTest extends RsaKeyAwareTest {
                         .put("some_settings_2", 210)
                         .build();
 
-        final var client = s3ClientProvider.buildClientIfNeeded(S3ClientSettings.create(settings), repoSettings);
+        final var client =
+                s3ClientProvider.buildClientIfNeeded(
+                        S3ClientSettings.create(settings).get("default"),
+                        repoSettings
+                ).v2();
         final var amazonS3Client = (AmazonS3Client) client;
 
         assertEquals(S3ClientProvider.HTTP_USER_AGENT, amazonS3Client.getClientConfiguration().getUserAgentPrefix());
@@ -88,11 +112,16 @@ class S3ClientProviderTest extends RsaKeyAwareTest {
         final var s3ClientProvider = new S3ClientProvider();
         final var secureSettings =
                 new DummySecureSettings()
-                        .setString(S3ClientSettings.AWS_ACCESS_KEY_ID.getKey(), "AWS_ACCESS_KEY_ID")
-                        .setString(S3ClientSettings.AWS_SECRET_ACCESS_KEY.getKey(), "AWS_SECRET_ACCESS_KEY")
-                        .setString(S3ClientSettings.ENDPOINT.getKey(), "http://endpoint")
-                        .setFile(S3ClientSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
-                        .setFile(S3ClientSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
+                        .setString(AWS_ACCESS_KEY_ID.getConcreteSettingForNamespace("default").getKey(),
+                                "AWS_ACCESS_KEY_ID")
+                        .setString(AWS_SECRET_ACCESS_KEY.getConcreteSettingForNamespace("default").getKey(),
+                                "AWS_SECRET_ACCESS_KEY")
+                        .setString(ENDPOINT.getConcreteSettingForNamespace("default").getKey(),
+                                "http://endpoint")
+                        .setFile(PUBLIC_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                                Files.newInputStream(publicKeyPem))
+                        .setFile(PRIVATE_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                                Files.newInputStream(privateKeyPem));
 
         final var settings =
                 Settings.builder().setSecureSettings(secureSettings).build();
@@ -103,7 +132,11 @@ class S3ClientProviderTest extends RsaKeyAwareTest {
                         .build();
 
 
-        final var client = s3ClientProvider.buildClientIfNeeded(S3ClientSettings.create(settings), repoSettings);
+        final var client =
+                s3ClientProvider.buildClientIfNeeded(
+                        S3ClientSettings.create(settings).get("default"),
+                        repoSettings
+                ).v2();
         final var amazonS3Client = (AmazonS3Client) client;
 
         assertEquals(S3ClientProvider.HTTP_USER_AGENT, amazonS3Client.getClientConfiguration().getUserAgentPrefix());
@@ -123,11 +156,16 @@ class S3ClientProviderTest extends RsaKeyAwareTest {
         final var s3ClientProvider = new S3ClientProvider();
         final var secureSettings =
                 new DummySecureSettings()
-                        .setString(S3ClientSettings.AWS_ACCESS_KEY_ID.getKey(), "AWS_ACCESS_KEY_ID")
-                        .setString(S3ClientSettings.AWS_SECRET_ACCESS_KEY.getKey(), "AWS_SECRET_ACCESS_KEY")
-                        .setString(S3ClientSettings.ENDPOINT.getKey(), "http://endpoint")
-                        .setFile(S3ClientSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
-                        .setFile(S3ClientSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
+                        .setString(AWS_ACCESS_KEY_ID.getConcreteSettingForNamespace("default").getKey(),
+                                "AWS_ACCESS_KEY_ID")
+                        .setString(AWS_SECRET_ACCESS_KEY.getConcreteSettingForNamespace("default").getKey(),
+                                "AWS_SECRET_ACCESS_KEY")
+                        .setString(ENDPOINT.getConcreteSettingForNamespace("default").getKey(),
+                                "http://endpoint")
+                        .setFile(PUBLIC_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                                Files.newInputStream(publicKeyPem))
+                        .setFile(PRIVATE_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                                Files.newInputStream(privateKeyPem));
 
         final var settings =
                 Settings.builder().setSecureSettings(secureSettings).build();
@@ -137,7 +175,11 @@ class S3ClientProviderTest extends RsaKeyAwareTest {
                 Settings.builder()
                         .put(CommonSettings.RepositorySettings.MAX_RETRIES.getKey(), 20)
                         .build();
-        final var client = s3ClientProvider.buildClientIfNeeded(S3ClientSettings.create(settings), repoSettings);
+        final var client =
+                s3ClientProvider.buildClientIfNeeded(
+                        S3ClientSettings.create(settings).get("default"),
+                        repoSettings
+                ).v2();
         final var amazonS3Client = (AmazonS3Client) client;
 
         assertEquals(S3ClientProvider.HTTP_USER_AGENT, amazonS3Client.getClientConfiguration().getUserAgentPrefix());
@@ -157,11 +199,16 @@ class S3ClientProviderTest extends RsaKeyAwareTest {
         final var s3ClientProvider = new S3ClientProvider();
         final var secureSettings =
                 new DummySecureSettings()
-                        .setString(S3ClientSettings.AWS_ACCESS_KEY_ID.getKey(), "AWS_ACCESS_KEY_ID")
-                        .setString(S3ClientSettings.AWS_SECRET_ACCESS_KEY.getKey(), "AWS_SECRET_ACCESS_KEY")
-                        .setString(S3ClientSettings.ENDPOINT.getKey(), "http://endpoint")
-                        .setFile(S3ClientSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
-                        .setFile(S3ClientSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
+                        .setString(AWS_ACCESS_KEY_ID.getConcreteSettingForNamespace("default").getKey(),
+                                "AWS_ACCESS_KEY_ID")
+                        .setString(AWS_SECRET_ACCESS_KEY.getConcreteSettingForNamespace("default").getKey(),
+                                "AWS_SECRET_ACCESS_KEY")
+                        .setString(ENDPOINT.getConcreteSettingForNamespace("default").getKey(),
+                                "http://endpoint")
+                        .setFile(PUBLIC_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                                Files.newInputStream(publicKeyPem))
+                        .setFile(PRIVATE_KEY_FILE.getConcreteSettingForNamespace("default").getKey(),
+                                Files.newInputStream(privateKeyPem));
 
         final var settings =
                 Settings.builder().setSecureSettings(secureSettings).build();
@@ -172,7 +219,11 @@ class S3ClientProviderTest extends RsaKeyAwareTest {
                         .put(CommonSettings.RepositorySettings.MAX_RETRIES.getKey(), 20)
                         .put(S3ClientProvider.ENDPOINT_NAME.getKey(), "http://new-endpoint")
                         .build();
-        final var client = s3ClientProvider.buildClientIfNeeded(S3ClientSettings.create(settings), repoSettings);
+        final var client =
+                s3ClientProvider.buildClientIfNeeded(
+                        S3ClientSettings.create(settings).get("default"),
+                        repoSettings
+                ).v2();
         final var amazonS3Client = (AmazonS3Client) client;
 
         assertEquals(S3ClientProvider.HTTP_USER_AGENT, amazonS3Client.getClientConfiguration().getUserAgentPrefix());

--- a/repository-s3/src/test/java/io/aiven/elasticsearch/repositories/s3/S3StorageIOTest.java
+++ b/repository-s3/src/test/java/io/aiven/elasticsearch/repositories/s3/S3StorageIOTest.java
@@ -69,7 +69,7 @@ class S3StorageIOTest extends RsaKeyAwareTest {
                         Files.newInputStream(privateKeyPem).readAllBytes());
 
         final var s3StorageIO =
-                new S3RepositoryStorageIOProvider(null, encProvider)
+                new S3RepositoryStorageIOProvider(null)
                         .createStorageIOFor(
                                 mockedAmazonS3,
                                 Settings.builder()
@@ -120,7 +120,7 @@ class S3StorageIOTest extends RsaKeyAwareTest {
                 .thenReturn(mock(DeleteObjectsResult.class));
 
         final var s3StorageIO =
-                new S3RepositoryStorageIOProvider(null, encProvider)
+                new S3RepositoryStorageIOProvider(null)
                         .createStorageIOFor(
                                 mockedAmazonS3,
                                 Settings.builder()


### PR DESCRIPTION
Migration to affix settings

- Load of client settings as Map
- `EncryptionKeyProvider` now creates/recreates together with client

All plugins now have  such prefix:

- `aive.azure.*.<settings_name>`
- `aive.gcs.*.<settings_name>`
- `aive.s3.*.<settings_name>`
