### PR TITLE
Clean stale encryption key

### DIFF
--- a/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/RepositoryStorageIOProvider.java
+++ b/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/RepositoryStorageIOProvider.java
@@ -120,6 +120,7 @@ public abstract class RepositoryStorageIOProvider<C, S extends CommonSettings.Cl
         if (Objects.nonNull(clientProvider)) {
             clientProvider.close();
         }
+        encryptionKey = null;
     }
 
     protected abstract StorageIO createStorageIOFor(final C client,


### PR DESCRIPTION
When repository was closed, an encryption key stayed in the memory.
As result in the case of re-registering of the repository, it did not reload.